### PR TITLE
Splitted instructions into README.md and INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -93,3 +93,8 @@ If all is right, you must now have a folder called `build`, into `qibocal/doc`.
 
 We developed the site using `yarn` as dependence. You can install it following the
 [official instructions](https://yarnpkg.com/getting-started/install).
+
+###### Required packages to compile it in dev mode
+
+Please check the "dependencies" section in `package.json` file to be sure that you
+have all the yarn extensions in order to run the developer mode.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,11 +14,8 @@ Let's check if you have correctly installed `virtualenv` by running:
 which virtualenv
 ```
 
-If yes, you will read its path location on the terminal. If not, you can install it following:
-
-```bash
-pip install virtualenv
-```
+If yes, you will read its path location on the terminal. If not, you can install it following
+the [official instructions](https://virtualenv.pypa.io/en/latest/installation.html).
 
 Now we create an environment that we will use for building the docs using the following command:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,95 @@
+## Installation instructions
+
+In order to run the site in developement mode you need some packages to be installed.
+
+#### Installing `sphinx` into a `virtualenv`
+
+At first, you need to have `sphinx` properly working on your environment. It is needed
+because the next step is to build the documentations locally. 
+
+We suggest to install it into a `virtualenv` and for doing this we first need an environment.
+Let's check if you have correctly installed `virtualenv` by running:
+
+```bash
+which virtualenv
+```
+
+If yes, you will read its path location on the terminal. If not, you can install it following:
+
+```bash
+pip install virtualenv
+```
+
+Now we create an environment that we will use for building the docs using the following command:
+
+```bash
+virtualenv my-sphinx-env
+```
+
+Let's activate the new environment:
+
+```bash
+source my-sphinx-env/bin/activate
+```
+
+Now you will read the name of your environment `(my-sphinx-env)` on the right side of the command line.
+Here we are, now we can proceed with the installation of `sphinx`.
+
+You can do this running following the 
+[official `sphinx` instructions](https://smobsc.readthedocs.io/en/stable/usage/installation.html).
+On Linux or MacOS run:
+
+```bash
+pip install -U sphinx
+```
+
+or on the Windows prompt:
+
+```bash
+pip install -U --pre sphinx
+```
+
+Now the environment is ready to build the documentations.
+
+#### Building the docs
+
+The Qibo site needs the documentations to be generated locally. 
+
+###### Qibo docs
+
+For building `qibo`'s documentation run:
+
+```bash
+cd public/packages/qibo/doc
+make html
+```
+
+If all is right, you must now have a folder called `build`, into `qibo/doc`.
+
+###### Qibolab docs
+
+For building `qibolab`'s documentation come back to root into `qibogang.github.io` and run:
+
+```bash
+cd public/packages/qibolab/doc
+make html
+```
+
+If all is right, you must now have a folder called `build`, into `qibolab/doc`.
+
+###### Qibocal docs
+
+For building `qibocal`'s documentation come back to root into `qibogang.github.io` and run:
+
+```bash
+cd public/packages/qibocal/doc
+make html
+```
+
+If all is right, you must now have a folder called `build`, into `qibocal/doc`.
+
+
+#### We use `yarn` as dependence
+
+We developed the site using `yarn` as dependence. You can install it following the
+[official instructions](https://yarnpkg.com/getting-started/install).

--- a/README.md
+++ b/README.md
@@ -6,11 +6,7 @@ Here we describe its contents and show you how to run the site in developement m
 
 ### How to open the site in developement mode
 
-First, you need to clone this repo locally. For doing this, enter in the location in which you want the Qibo site folder and digit: 
-
-```bash
-git clone https://github.com/qibogang/qibogang.github.io.git
-```
+First, you need to clone this repo locally. 
 
 ##### The qibo site needs qibo, qibolab and qibocal
 

--- a/README.md
+++ b/README.md
@@ -1,40 +1,38 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+This is the Qibo's website repository.
+Here we describe its contents and show you how to run the site in developement mode, in order to collaborate with us.
 
-It is an experimental repo, created to familiarize with `nextjs`, `javascript` and `react`.
 
-## How to run the site in developement mode
+## How to open the site in developement mode
 
 First, you need to clone this repo locally. For doing this, enter in the location in which you want the Qibo site folder and digit: 
 
 ```bash
-git clone https://github.com/qibogang/qibogang.github.io.git --recurse-submodules
+git clone https://github.com/qibogang/qibogang.github.io.git
 ```
 
-Second, the Qibo site needs the documentation pages to be built locally. 
-In order to do that, you must enter the `public/packages/qibo/doc` (and the same must be done also for Qibocal and Qibocal) folder and to run:
+#### The qibo site needs qibo, qibolab and qibocal
+
+This repo uses other three repos to properly build the documentations. We need to 
+get the correct `submodules` in order to do that. After having cloned the repo, follow these
+instructions:
 
 ```bash
-cd qibogang.github.io/public/packages/qibo/doc
-make html
+cd qibogang.github.io
+git submodules init
+git submodules update
 ```
 
-This command will build the `index.html` file representing the qibo documentation.
-Note that, for doing this, you need to be into an environment in which you have installed `sphinx` properly.
-If you install the packages using `pip` it is important to add the flag which activate the documentation packages.
-You can do this running the following line into the `qibo` (or `qibolab/cal`) folder:
+#### Follow `INSTALL.md` instructions now
+
+The next step is to install some more packages. 
+Please follow the [installation istructions]("./INSTALL.md").
+
+
+#### Run the site in developement mode!
+
+Here we are! After all the dependences are ready, you can run the developement mode:
 
 ```bash
-pip install .[docs]
-```
-
-Otherwise, if you install the packages with `poetry`, you will be able to run `make html` without any problem.
-
-Here we are!
-As final step you have to install yarn and run the development server:
-
-```bash
-npm install --global yarn
-yarn install
 yarn dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ git submodules update
 ##### Follow `INSTALL.md` instructions now
 
 The next step is to install some more packages. 
-Please follow the [installation istructions]("https://github.com/qibogang/qibogang.github.io/blob/installation_istructions/INSTALL.md").
+Please follow the [installation istructions](https://github.com/qibogang/qibogang.github.io/blob/installation_istructions/INSTALL.md).
 
 
 ##### Run the site in developement mode!

--- a/README.md
+++ b/README.md
@@ -57,7 +57,3 @@ Into this repo you will find some folders:
 - `tutorials` contains some markdowns corresponding to the tutorials presented to the user. Each tutorial is saved into a proper `.md` file.
 - `styles` contains two `*.css` files in which we wrote some styling instructions for the site building.
 
-### Required packages to compile it in dev mode
-
-Please check the "dependencies" section in `package.json` file to be sure that you
-have all the yarn extensions in order to run the developer mode.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
+# Qibo site instructions
+
 This is the Qibo's website repository.
 Here we describe its contents and show you how to run the site in developement mode, in order to collaborate with us.
 
 
-## How to open the site in developement mode
+### How to open the site in developement mode
 
 First, you need to clone this repo locally. For doing this, enter in the location in which you want the Qibo site folder and digit: 
 
@@ -10,7 +12,7 @@ First, you need to clone this repo locally. For doing this, enter in the locatio
 git clone https://github.com/qibogang/qibogang.github.io.git
 ```
 
-#### The qibo site needs qibo, qibolab and qibocal
+##### The qibo site needs qibo, qibolab and qibocal
 
 This repo uses other three repos to properly build the documentations. We need to 
 get the correct `submodules` in order to do that. After having cloned the repo, follow these
@@ -22,13 +24,13 @@ git submodules init
 git submodules update
 ```
 
-#### Follow `INSTALL.md` instructions now
+##### Follow `INSTALL.md` instructions now
 
 The next step is to install some more packages. 
 Please follow the [installation istructions]("./INSTALL.md").
 
 
-#### Run the site in developement mode!
+##### Run the site in developement mode!
 
 Here we are! After all the dependences are ready, you can run the developement mode:
 
@@ -45,7 +47,7 @@ You can start editing the page by modifying `pages/index.js` (we talk about `ind
 The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
 
 
-## Repo's structure
+### Repo's structure
 
 Into this repo you will find some folders:
 
@@ -55,7 +57,7 @@ Into this repo you will find some folders:
 - `tutorials` contains some markdowns corresponding to the tutorials presented to the user. Each tutorial is saved into a proper `.md` file.
 - `styles` contains two `*.css` files in which we wrote some styling instructions for the site building.
 
-## Required packages to compile it in dev mode
+### Required packages to compile it in dev mode
 
 Please check the "dependencies" section in `package.json` file to be sure that you
 have all the yarn extensions in order to run the developer mode.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ git submodules update
 ##### Follow `INSTALL.md` instructions now
 
 The next step is to install some more packages. 
-Please follow the [installation istructions]("./INSTALL.md").
+Please follow the [installation istructions]("https://github.com/qibogang/qibogang.github.io/blob/installation_istructions/INSTALL.md").
 
 
 ##### Run the site in developement mode!


### PR DESCRIPTION
I have divided the instructions into two files:

- `README.md` contains the repo's description, the cloning instructions and the instructions for running the site in development mode;
- `INSTALL.md` contains all the installation instructions.