### PR TITLE
fix urls in built mode

### DIFF
--- a/components/DropNav.js
+++ b/components/DropNav.js
@@ -35,9 +35,9 @@ const DropNav = () => {
           <div className="dropdown">
             <button className="dropbtn">Documentation</button>
               <div className="dropdown-content">
-                <a href="/docs/qibo/last">Qibo</a>
-                <a href="/docs/qibolab/last">Qibolab</a>
-                <a href="/docs/qibocal/last">Qibocal</a>
+                <a href="/docs/qibo/last.html">Qibo</a>
+                <a href="/docs/qibolab/last.html">Qibolab</a>
+                <a href="/docs/qibocal/last.html">Qibocal</a>
               </div>
           </div> 
           

--- a/components/DynNavbar.js
+++ b/components/DynNavbar.js
@@ -25,9 +25,9 @@ const DropNav = () => {
           <div className="dropdown">
             <button className="dropbtn">Documentation</button>
               <div className="dropdown-content">
-                <a href="/docs/qibo/last">Qibo</a>
-                <a href="/docs/qibolab/last">Qibolab</a>
-                <a href="/docs/qibocal/last">Qibocal</a>
+                <a href="/docs/qibo/last.html">Qibo</a>
+                <a href="/docs/qibolab/last.html">Qibolab</a>
+                <a href="/docs/qibocal/last.html">Qibocal</a>
               </div>
           </div> 
           

--- a/components/QibocalNavbar.js
+++ b/components/QibocalNavbar.js
@@ -32,9 +32,9 @@ const DropNav = () => {
           <div className="dropdown">
             <button className="dropbtn">Documentation</button>
               <div className="dropdown-content">
-                <a href="/docs/qibo/last">Qibo</a>
-                <a href="/docs/qibolab/last">Qibolab</a>
-                <a href="/docs/qibocal/last">Qibocal</a>
+                <a href="/docs/qibo/last.html">Qibo</a>
+                <a href="/docs/qibolab/last.html">Qibolab</a>
+                <a href="/docs/qibocal/last.html">Qibocal</a>
               </div>
           </div> 
           

--- a/components/QibolabNavbar.js
+++ b/components/QibolabNavbar.js
@@ -33,9 +33,9 @@ const DropNav = () => {
           <div className="dropdown">
             <button className="dropbtn">Documentation</button>
               <div className="dropdown-content">
-                <a href="/docs/qibo/last">Qibo</a>
-                <a href="/docs/qibolab/last">Qibolab</a>
-                <a href="/docs/qibocal/last">Qibocal</a>
+                <a href="/docs/qibo/last.html">Qibo</a>
+                <a href="/docs/qibolab/last.html">Qibolab</a>
+                <a href="/docs/qibocal/last.html">Qibocal</a>
               </div>
           </div> 
           


### PR DESCRIPTION
After a discussion with @Edoardo-Pedicillo, I modified the `url` references into the navbars, in order to correctly compute the docs' pages once the site is built (in my case with `yarn build`) and opened from the `out` folder which is created through (`yarn next export`).

After this modification the pages are correctly showed in built mode but the error occurs in development mode. I'm trying to understand the reason of this. 

I suggest to wait for the merge, if we plan to be able to show all the site in development mode from the `master` branch.