### PR TITLE
reusable workflow to deploy Next.js to Pages 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,4 +9,4 @@ on:
 jobs:
 
   deploy-docs:
-    uses: qibogang/workflows/.github/workflows/publish-next-to-ghpages.yml@main
+    uses: qibogang/workflows/.github/workflows/publish-next-on-ghpages.yml@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,73 +1,12 @@
 name: Deploy Next.js site to Pages
 
-on:
-  # Runs on pushes targeting the default branch
-  push:
-    branches: [master]
 
-  # Allows you to run this workflow manually from the Actions tab
+on: 
   workflow_dispatch:
-
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-# Allow one concurrent deployment
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
-
+  push:
+      branches: [master,new_workflow]
+  
 jobs:
-  # Build job
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: "16"
-          cache: yarn
-      - name: Setup Pages
-        uses: actions/configure-pages@v2
-        with:
-          # Automatically inject basePath in your Next.js configuration file and disable
-          # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
-          #
-          # You may remove this line if you want to manage the configuration yourself.
-          static_site_generator: next
-      - name: Restore cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            .next/cache
-          # Generate a new cache whenever packages or source files change.
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
-          # If source files changed but packages didn't, rebuild from a prior cache.
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-
-      - name: Install dependencies
-        run: yarn install
-      - name: Build with Next.js
-        run: yarn build
-      - name: Static HTML export with Next.js
-        run: yarn next export
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
-        with:
-          path: ./out
 
-  # Deployment job
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v1
+  deploy-docs:
+    uses: qibogang/workflows/.github/workflows/publish-next-to-ghpages@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,5 +8,5 @@ on:
   
 jobs:
 
-  deploy-docs:
+  publish:
     uses: qibogang/workflows/.github/workflows/publish-next-on-ghpages.yml@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,4 +9,4 @@ on:
 jobs:
 
   deploy-docs:
-    uses: qibogang/workflows/.github/workflows/publish-next-to-ghpages@main
+    uses: qibogang/workflows/.github/workflows/publish-next-to-ghpages.yml@main


### PR DESCRIPTION
In this PR, I have changed the `publish.yml` workflow in order to implement the reusable workflow `publish-next-on-ghpages.yml`.