### PR TITLE
Fixing tutorial height

### DIFF
--- a/pages/tutorials.js
+++ b/pages/tutorials.js
@@ -10,7 +10,7 @@ import Footer from '../components/Footer'
 
 
 const Hero = styled.div`
-  height: 88vh;
+  min-height: 88vh;
   display: flex;
   padding-bottom: 10px;
   justify-content: center;


### PR DESCRIPTION
In this PR the `tutorials.js` height is controlled by `min-height`. This makes it flexible and solves the problem of the white space below the first three cards.